### PR TITLE
Fixed Inf comparison

### DIFF
--- a/nuts_with_dual_averaging.jl
+++ b/nuts_with_dual_averaging.jl
@@ -31,7 +31,7 @@ function NUTS(θ0, δ, L, M, Madapt, verbose=true)
     # This trick prevents the log-joint or its graident from being infinte
     # Ref: code start from Line 111 in https://github.com/mfouesneau/NUTS/blob/master/nuts.py
     # QUES: will this lead to some bias of the sampler?
-    while L(θ′) == -Inf || ∇L(θ′) == -Inf
+    while isinf(L(θ′)) || any(isinf(∇L(θ′)))
       ϵ = ϵ * 0.5
       θ′, r′ = leapfrog(θ, r, ϵ)
     end


### PR DESCRIPTION
In the original code
```julia
while L(θ′) == -Inf || ∇L(θ′) == -Inf
```
the intent seems to be to determine whether the log-likelihood or any component of its gradient is infinite. This is supported by the referenced Python, in the line
```python
while np.isinf(logpprime) or np.isinf(gradprime).any():
```

The Julia code is subtly different:
1. It tests only for *negatively* infinite log-likelihood
2. The test `∇L(θ′) == -Inf` compares a scalar and a gradient, almost certainly a bug.

This is easily corrected by changing the line to 
```julia
while isinf(L(θ′)) || any(isinf(∇L(θ′)))
```